### PR TITLE
V2.20

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - build/label/build
-  - https://staging.continuum.io/pbp/fs/tensorflow-feedstock/pr14/b2f25b0

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - build/label/build
+  - https://staging.continuum.io/pbp/fs/tensorflow-feedstock/pr14/b2f25b0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tf-keras" %}
-{% set version = "2.18.0" %}
+{% set version = "2.20.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,16 +7,13 @@ package:
 
 source:
   - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/tf_keras-{{ version }}.tar.gz
-    sha256: ebf744519b322afead33086a2aba872245473294affd40973694f3eb7c7ad77d
+    sha256: 884be5938fb0b2b53b1583c1ae2b660ef87215377c29b5b6a77fd221b472aeaf
   - fn: LICENSE
     url: https://raw.githubusercontent.com/keras-team/tf-keras/v{{ version }}/LICENSE
     sha256: 58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd
 
 build:
-  # skip osx-64 because of failed import of tf-keras:
-  # ImportError: cannot import name 'training_distributed_v1' from 'tensorflow.python.keras.engine'
-  # tensorflow unavailable for python 3.13
-  skip: True  # [py>=313 or (osx and x86_64)]
+  skip: True  # [py>313]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
 
@@ -31,7 +28,7 @@ requirements:
     # added scipy from requirements.txt because it seems to be used in production code in tf_keras/preprocessing/image.py
     # and is not explicitly listed as an optional dependency
     - scipy
-    - tensorflow >=2.18.0,<2.19.0
+    - tensorflow >=2.20.0,<2.21.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,9 +34,7 @@ test:
   imports:
     - tf_keras
   commands:
-      # Skip pip check on Windows due to conda/pip metadata conflict:
-      # tf-keras conda package references pip tensorflow dependency but we have conda tensorflow
-    - pip check  # [not win]
+    - pip check
   requires:
     - pip
     - python


### PR DESCRIPTION
tf-keras v2.20.1

**Destination channel:**  defaults

### Links

- [PKG-10307](https://anaconda.atlassian.net/browse/PKG-10307) 
- [Upstream repository](https://github.com/keras-team/tf-keras/tree/v2.20.1)
- [Upstream changelog/diff](https://github.com/keras-team/tf-keras/releases/tag/v2.20.1)

### Explanation of changes:

- Bump version and SHA
- Build for 3.13 now that tensorflow 2.20 is available
- Re-enable pip check in windows now that pip is detecting the correct package name for tensorflow. 


[PKG-10307]: https://anaconda.atlassian.net/browse/PKG-10307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ